### PR TITLE
Фоновый режим 2.0

### DIFF
--- a/examples/testBlink/testBlink.ino
+++ b/examples/testBlink/testBlink.ino
@@ -26,15 +26,15 @@ void setup() {
 void loop() {
   ntp.tick();
   
-  if (ntp.ms() == 0) {
+  if (ntp.ms() == 0) {// секунда почалась
     delay(1);
     digitalWrite(LED_BUILTIN, 1);
+    Serial.println(ntp.timeString()); //выводим
+    Serial.println(ntp.dateString());
+    Serial.println();
   }
   if (ntp.ms() == 500) {
     delay(1);
     digitalWrite(LED_BUILTIN, 0);
-    Serial.println(ntp.timeString());
-    Serial.println(ntp.dateString());
-    Serial.println();
   }
 }


### PR DESCRIPTION
От что я имел ввиду.
Перед проверкой нужно синхронизировать время Windows (у меня за несколько часов почти секунда набигает)
Причины изминений:
1. Задержка сервера всегда 0
2. На вики написано что точность 2^-32 значит в одной секунде 2^32 долей
3. Для разчётов нам нужен точный текущий пинг

Я проверял несколько раз и оставлял на пару часов всё работает. В примере который я, изменил светодиод загорается когда меняется секунда на компе и через 500 мс (+-100) выводится в сериал.